### PR TITLE
SUPPORT-724 deleted git-commit-id-plugin

### DIFF
--- a/core/template.mf
+++ b/core/template.mf
@@ -35,7 +35,6 @@ Spring-Version: ${spring.maven.artifact.version}
 Build-Jdk: ${java.version}
 Build-Plan: ${env.buildPlan}
 Build-Number: ${env.buildNumber}
-Git-Revision: ${git.commit.id.describe}
 Excluded-Imports: com_cenqua_clover*
 Ignored-Existing-Headers:
  Ant-Version,

--- a/extender/template.mf
+++ b/extender/template.mf
@@ -32,7 +32,6 @@ Spring-Version: ${spring.maven.artifact.version}
 Build-Jdk: ${java.version}
 Build-Plan: ${env.buildPlan}
 Build-Number: ${env.buildNumber}
-Git-Revision: ${git.commit.id.describe}
 Excluded-Imports: com_cenqua_clover*
 Ignored-Existing-Headers:
  Ant-Version,

--- a/io/template.mf
+++ b/io/template.mf
@@ -24,7 +24,6 @@ Spring-Version: ${spring.maven.artifact.version}
 Build-Jdk: ${java.version}
 Build-Plan: ${env.buildPlan}
 Build-Number: ${env.buildNumber}
-Git-Revision: ${git.commit.id.describe}
 Ignored-Existing-Headers:
  Ant-Version,
  Archiver-Version,

--- a/mock/template.mf
+++ b/mock/template.mf
@@ -22,7 +22,6 @@ Spring-Version: ${spring.maven.artifact.version}
 Build-Jdk: ${java.version}
 Build-Plan: ${env.buildPlan}
 Build-Number: ${env.buildNumber}
-Git-Revision: ${git.commit.id.describe}
 Unversioned-Imports: *
 Excluded-Imports: com_cenqua_clover*
 Ignored-Existing-Headers:

--- a/pom.xml
+++ b/pom.xml
@@ -381,11 +381,6 @@
         <pluginManagement>
             <plugins>
                 <plugin>
-                    <groupId>pl.project13.maven</groupId>
-                    <artifactId>git-commit-id-plugin</artifactId>
-                    <version>2.1.5</version>
-                </plugin>
-                <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-resources-plugin</artifactId>
                     <version>2.6</version>
@@ -627,7 +622,6 @@
                             <Implementation-Vendor-Id>org.eclipse.gemini.blueprint</Implementation-Vendor-Id>
                             <Gemini-Blueprint-Version>${project.version}</Gemini-Blueprint-Version>
                             <Spring-Version>${spring.maven.artifact.version}</Spring-Version>
-                            <Git-Revision>${git.commit.id.describe}</Git-Revision>
                             <Eclipse-SourceBundle>${spring.osgi.symbolic.name};version="${project.version}";roots:="."
                             </Eclipse-SourceBundle>
                         </manifestEntries>
@@ -741,89 +735,6 @@
                 </configuration>
             </plugin>
 
-            <plugin>
-                <groupId>pl.project13.maven</groupId>
-                <artifactId>git-commit-id-plugin</artifactId>
-                <version>2.1.5</version>
-                <executions>
-                    <execution>
-                        <goals>
-                            <goal>revision</goal>
-                        </goals>
-                    </execution>
-                </executions>
-
-                <configuration>
-                    <!-- that's the default value, you don't have to set it -->
-                    <prefix>git</prefix>
-                    <!-- that's the default value -->
-                    <dateFormat>dd.MM.yyyy '@' HH:mm:ss z</dateFormat>
-                    <!-- true is default here, it prints some more information during the build -->
-                    <verbose>fasle</verbose>
-                    <!--
-                        If you'd like to tell the plugin where your .git directory is,
-                        use this setting, otherwise we'll perform a search trying to
-                        figure out the right directory. It's better to add it explicit IMHO.
-                    -->
-                    <dotGitDirectory>${project.basedir}/.git</dotGitDirectory>
-
-                    <!-- ALTERNATE SETUP - GENERATE FILE -->
-                    <!--
-                        If you want to keep git information, even in your WAR file etc,
-                        use this mode, which will generate a properties file (with filled out values)
-                        which you can then normally read using new Properties().load(/**/)
-                    -->
-
-                    <!--
-                        this is true by default; You may want to set this to false, if the plugin should run inside a
-                        <packaging>pom</packaging> project. Most projects won't need to override this property.
-
-                        For an use-case for this kind of behaviour see: https://github.com/ktoso/maven-git-commit-id-plugin/issues/21
-                    -->
-                    <skipPoms>true</skipPoms>
-
-                    <!-- this is false by default, forces the plugin to generate the git.properties file -->
-                    <generateGitPropertiesFile>true</generateGitPropertiesFile>
-
-                    <!-- The path for the to be generated properties file, it's relative to ${project.basedir} -->
-                    <generateGitPropertiesFilename>src/main/resources/git.properties</generateGitPropertiesFilename>
-
-                    <!-- true by default, controls whether the plugin will fail when no .git directory is found, when set to false the plugin will just skip execution -->
-                    <!-- @since 2.0.4 -->
-                    <failOnNoGitDirectory>false</failOnNoGitDirectory>
-
-                    <!-- @since 2.1.0 -->
-                    <!--
-                        read up about git-describe on the in man, or it's homepage - it's a really powerful versioning helper
-                        and the recommended way to use git-commit-id-plugin. The configuration bellow is optional,
-                        by default describe will run "just like git-describe on the command line", even though it's a JGit reimplementation.
-                    -->
-                    <gitDescribe>
-                        <!-- don't generate the describe property -->
-                        <skip>false</skip>
-                        <!--
-                            if no tag was found "near" this commit, just print the commit's id instead,
-                            helpful when you always expect this field to be not-empty
-                        -->
-                        <always>false</always>
-                        <!--
-                             how many chars should be displayed as the commit object id?
-                             7 is git's default,
-                             0 has a special meaning (see end of this README.md),
-                             and 40 is the maximum value here
-                        -->
-                        <abbrev>7</abbrev>
-
-                        <!-- when the build is triggered while the repo is in "dirty state", append this suffix -->
-                        <dirty>-dirty</dirty>
-                        <!--
-                             always print using the "tag-commits_from_tag-g_commit_id-maybe_dirty" format, even if "on" a tag.
-                             The distance will always be 0 if you're "on" the tag.
-                        -->
-                        <forceLongFormat>false</forceLongFormat>
-                    </gitDescribe>
-                </configuration>
-            </plugin>
         </plugins>
     </build>
 

--- a/test-support/template.mf
+++ b/test-support/template.mf
@@ -33,7 +33,6 @@ Spring-Version: ${spring.maven.artifact.version}
 Build-Jdk: ${java.version}
 Build-Plan: ${env.buildPlan}
 Build-Number: ${env.buildNumber}
-Git-Revision: ${git.commit.id.describe}
 Ignored-Existing-Headers:
  Ant-Version,
  Archiver-Version,


### PR DESCRIPTION
удаление плагина git-commit-id-plugin для исключения необходимости в папке .git